### PR TITLE
Add confirm-submit apply flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ Job-pro releases are tracked on npm: <https://www.npmjs.com/package/job-pro>.
 This file is the human-readable narrative of how we got here, not a
 mechanical diff log — for that, `git log --oneline cli/`.
 
+## Unreleased — `apply --confirm-submit`: preview, confirm, then fire
+
+`apply` no longer makes an interactive user copy a second command just to
+move from "resume looks OK" to "submit it." New flags:
+
+* `--confirm-submit` stages the application, prints the final payload,
+  asks for one explicit confirmation, then runs the existing official-site
+  submitter for that adapter.
+* `--submit-after-confirm` is an alias for the same flow.
+* `--really-submit` still exists for scripts and keeps the
+  `JOB_PRO_I_UNDERSTAND_REAL_SUBMIT=yes` attestation.
+
+Batch real submission remains refused by design; use `--debug-submit-to`
+for batch wire-format checks, then submit individual jobs after preview.
+
 ## 1.0.93 — `match` actually works: docx/pdf/json resume input, fixed false positives, degree-aware sort
 
 `job-pro <co> match` used to require a plain-text resume on stdin and

--- a/README.md
+++ b/README.md
@@ -87,11 +87,9 @@ Add `--compact` to any command for a single-line JSON output (pipe-friendly).
 
 Submit applications from the CLI. 50 / 50 adapters expose an
 application schema; 45 / 50 have an executor wired (3 anon Greenhouse/Lever
-+ 42 session-required); **15 / 50 have endpoint-verified status** (3
-anon end-to-end smoked + 12 anon-probe-verified — alibaba, pdd, meituan,
-mihoyo, liauto, and the 7 Moka adapters); the other 30 fire only with
-`JOB_PRO_ALLOW_SPECULATIVE_ENDPOINT=yes` (4th safety gate). The 5
-external (Liepin × 4 + Unitree WeChat) are structurally IM-mediated.
++ 42 session-required); **45 / 50 have endpoint-verified status**. The 5
+external adapters (Liepin × 4 + Unitree WeChat) are structurally
+IM-mediated and intentionally stay browser / chat handoff only.
 
 ```bash
 # 1. Set up your profile (one-time)
@@ -110,6 +108,9 @@ job-pro xpeng apply 8548990002 --interactive --remember  # fills answers, persis
 job-pro xpeng apply 8548990002 --debug-submit-to https://httpbin.org/post
 
 # 5. Actually submit
+job-pro xpeng apply 8548990002 --confirm-submit
+
+# Script mode still exists when you intentionally do not want a prompt:
 JOB_PRO_I_UNDERSTAND_REAL_SUBMIT=yes \
   job-pro xpeng apply 8548990002 --really-submit
 ```
@@ -122,14 +123,14 @@ careers site once, click Export, then drop
 
 ```bash
 # After capturing nio's session via the extension:
-JOB_PRO_I_UNDERSTAND_REAL_SUBMIT=yes \
-  job-pro nio apply 7639693860494543167 --really-submit
+job-pro nio apply 7639693860494543167 --confirm-submit
 ```
 
-The CLI gates `--really-submit` behind four layers (refuses with a
-clear `mode: really-submit-blocked` JSON at the first that fails):
+The CLI gates real submission behind four layers (refuses with a clear
+JSON mode at the first that fails):
 
-1. `JOB_PRO_I_UNDERSTAND_REAL_SUBMIT=yes` env-var attestation.
+1. User consent: either `--confirm-submit` interactive confirmation, or
+   `JOB_PRO_I_UNDERSTAND_REAL_SUBMIT=yes` with `--really-submit` for scripts.
 2. `staged.ready` — every required field is filled.
 3. `endpoint_verified === true` (URL probe-confirmed or end-to-end
    smoked) — bypass with `JOB_PRO_ALLOW_SPECULATIVE_ENDPOINT=yes`.
@@ -138,8 +139,8 @@ clear `mode: really-submit-blocked` JSON at the first that fails):
 
 Bulk-stage with `apply --batch <file|-` (newline-separated post_ids;
 `-` reads stdin); pairs with `--form-file` for uniform answers. Batch
-intentionally refuses `--really-submit` — verify wire format with
-`--debug-submit-to`, then submit jobs individually.
+intentionally refuses real submission — verify wire format with
+`--debug-submit-to`, then submit jobs individually with `--confirm-submit`.
 
 Five adapters (hikvision / cicc / cainiao / webank / unitree) are
 intentionally `external` — recruiting is mediated through Liepin

--- a/cli/src/agibot.ts
+++ b/cli/src/agibot.ts
@@ -50,7 +50,7 @@
 //   apply_url     — https://agirobot.jobs.feishu.cn/socialrecruitment/position/{id}/detail
 // ============================================================
 
-import { extractResumeSignals, scoreOverlap, checkResume, pickDistinctiveTerms } from "./tencent.js";
+import { extractResumeSignals, scoreOverlap, checkResume } from "./tencent.js";
 export { checkResume };
 
 const SOURCE = "agirobot.jobs.feishu.cn";

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -69,7 +69,9 @@ import {
   promptUnansweredFields,
   formatStaged,
   type ApplyFormSchema,
+  type CapturedSession,
   type ResumeProfile,
+  type StagedApplication,
 } from "./apply.js";
 import { createInterface } from "node:readline";
 import {
@@ -257,10 +259,11 @@ PHASE 2 (auto-apply) — 50/50 schema-ok, **45/50 endpoint-verified**:
   ✅ cdp-real-browser (1)  — lilith (puppeteer for ByteDance _signature bypass).
   ⛔ external (5)          — hikvision / cicc / cainiao / webank (Liepin chat),
                               unitree (WeChat QR). Structurally non-API.
-\`apply <postId>\` dry-runs the staged POST. \`--really-submit\` runs the
-4-layer safety gate (env attest + staged.ready + endpoint_verified +
-session<30d). Run \`job-pro list\` for the ✓ column or \`job-pro recon\`
-for the live probe matrix. See docs/auto-apply.md.
+\`apply <postId>\` dry-runs the staged POST. \`--confirm-submit\` previews
+the final payload, asks once, then fires the right official-site submitter.
+\`--really-submit\` remains available for scripts via env attestation. Run
+\`job-pro list\` for the ✓ column or \`job-pro recon\` for the live probe
+matrix. See docs/auto-apply.md.
 
 VERBS (same surface for every company)
   search <kw>                       search openings (free text)
@@ -285,6 +288,8 @@ VERBS (same surface for every company)
                                     --batch <file|->           apply to many post_ids (one/line)
                                     --debug-submit-to <url>    verify wire format
                                     --debug-submit             ↑ shorthand → httpbin.org/post
+                                    --confirm-submit           preview, ask once, then submit
+                                    --submit-after-confirm     alias for --confirm-submit
                                     --really-submit            actually fire (env-gated)
                                     --via-cdp                  drive a puppeteer browser through
                                                                the SPA's apply form (DOM-based,
@@ -454,6 +459,37 @@ async function readResumeByPath(path: string): Promise<string> {
   }
 }
 
+async function confirmRealApplicationSubmit(opts: {
+  company: string;
+  postId: string;
+  staged: StagedApplication;
+  session: CapturedSession | null;
+}): Promise<boolean> {
+  console.log(formatStaged(opts.staged));
+  if (opts.session) {
+    console.log(
+      `\nSession captured (~/.jobpro/${opts.company}.session.json): ` +
+        `${opts.session.cookies.length} cookies + ${Object.keys(opts.session.headers).length} auth headers.`
+    );
+  }
+  console.log(
+    `\nThis will submit a real application to ${opts.staged.submit_endpoint ?? opts.staged.apply_url}.`
+  );
+  console.log(
+    `Confirm the resume and answers above are OK, then type \`submit\` to continue.`
+  );
+
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const answer = await new Promise<string>((resolve) => {
+      rl.question(`Submit ${opts.company} ${opts.postId}? `, resolve);
+    });
+    return answer.trim().toLowerCase() === "submit";
+  } finally {
+    rl.close();
+  }
+}
+
 // Every company adapter exposes the same set of functions, so one dispatcher
 // can route verbs against any of them. New companies plug in by adding an
 // `import * as <name>` and a line in `ADAPTERS`. The `satisfies` clause
@@ -619,6 +655,8 @@ async function runCompany(
 
   if (verb === "apply") {
     const reallySubmit = args.includes("--really-submit");
+    const confirmSubmit =
+      args.includes("--confirm-submit") || args.includes("--submit-after-confirm");
     const viaCdp = args.includes("--via-cdp");
     const printForm = args.includes("--print-form");
     const schemaOnly = args.includes("--schema");
@@ -637,11 +675,11 @@ async function runCompany(
     // non-`#`-prefixed line is a post_id. Output is a JSON array of
     // { post_id, result } so downstream tooling can iterate.
     if (batchPath) {
-      if (reallySubmit) {
+      if (reallySubmit || confirmSubmit) {
         die(
-          `--batch + --really-submit is intentionally refused. Submitting to ` +
+          `--batch + real submission is intentionally refused. Submitting to ` +
             `multiple jobs at once is the exact failure mode this CLI is designed to ` +
-            `prevent. Drop --really-submit and use --debug-submit-to <url> for batch ` +
+            `prevent. Drop the real-submit flag and use --debug-submit-to <url> for batch ` +
             `verification, or run apply one job at a time.`
         );
       }
@@ -725,7 +763,7 @@ async function runCompany(
     void aBatch;
 
     const postId = args[0];
-    if (!postId) die(`usage: job-pro ${company} apply <post_id> [--schema | --print-form | --form-file <path> | --interactive [--remember] | --batch <file>] [--debug-submit-to <url> | --really-submit]`);
+    if (!postId) die(`usage: job-pro ${company} apply <post_id> [--schema | --print-form | --form-file <path> | --interactive [--remember] | --batch <file>] [--debug-submit-to <url> | --confirm-submit | --really-submit]`);
 
     const fetchSchema = adapter.fetchApplicationSchema;
     if (typeof fetchSchema !== "function") {
@@ -881,53 +919,39 @@ async function runCompany(
       return Math.floor((Date.now() - ts) / 86_400_000);
     }
 
-    // --really-submit: actually hit the upstream endpoint. Guarded by both
-    // an env-var attestation and (for non-anon adapters) a session.json.
-    if (reallySubmit) {
-      const understood = process.env.JOB_PRO_I_UNDERSTAND_REAL_SUBMIT === "yes";
-      if (!understood) {
-        return emit(
-          {
-            ok: false,
-            source: company,
-            post_id: postId,
-            mode: "really-submit-blocked",
-            staged,
-            message:
-              `--really-submit is gated by an env-var attestation. To unlock, set ` +
-              `JOB_PRO_I_UNDERSTAND_REAL_SUBMIT=yes in your shell. This submission will ` +
-              `POST a real application to ${staged.submit_endpoint}; doing so without a ` +
-              `valid resume / answers is spam against the company's recruiters.`,
-          },
-          compact
-        );
-      }
+    // Real submit: actually hit the upstream endpoint. `--confirm-submit`
+    // gates it through an interactive preview/confirmation; `--really-submit`
+    // gates it through an env-var attestation for scripts. Non-anon
+    // adapters still require a captured session.json.
+    if (reallySubmit || confirmSubmit) {
+      const blockedMode = confirmSubmit ? "confirm-submit-blocked" : "really-submit-blocked";
       if (!staged.ready) {
         return emit(
           {
             ok: false,
             source: company,
             post_id: postId,
-            mode: "really-submit-blocked",
+            mode: blockedMode,
             staged,
             message: `${staged.unanswered_required.length} required field(s) still unanswered; refusing to submit incomplete application`,
           },
           compact
         );
       }
+      const kind = (sr.schema.submit_kind ?? "multipart-anon");
       // Speculative-endpoint gate (4th safety layer). 19 of 22 bespoke
       // multipart-session endpoints returned 404 on no-auth probe — the
       // inferred URLs are wrong guesses. Refusing by default prevents
       // accidental fires against broken endpoints; users who *want* to
       // shake out what the real endpoint should be opt in via env.
       const allowSpeculative = process.env.JOB_PRO_ALLOW_SPECULATIVE_ENDPOINT === "yes";
-      if (staged.submit_kind !== "external" && staged.submit_kind !== "multipart-anon" && staged.endpoint_verified !== true && !allowSpeculative) {
+      if (kind !== "external" && staged.endpoint_verified !== true && !allowSpeculative) {
         return emit(
           {
             ok: false,
             source: company,
             post_id: postId,
-            mode: "really-submit-blocked",
+            mode: blockedMode,
             staged,
             message:
               `submit_endpoint for ${company} is speculative — inferred from JS-bundle recon, ` +
@@ -938,21 +962,13 @@ async function runCompany(
           compact
         );
       }
-      // Submission flow selection by submit_kind. Only the generic
-      // multipart families are wired to actually fire today; everything
-      // else gets a useful refusal message.
-      const kind = (sr.schema.submit_kind ?? "multipart-anon");
-      const isAnonMultipart = kind === "multipart-anon";
-      const isSessionMultipart = kind === "multipart-session";
-      const isGenericMultipart = isAnonMultipart || isSessionMultipart;
-
       if (kind === "external") {
         return emit(
           {
             ok: false,
             source: company,
             post_id: postId,
-            mode: "really-submit-external",
+            mode: confirmSubmit ? "confirm-submit-external" : "really-submit-external",
             staged,
             submit_kind: kind,
             apply_url: staged.apply_url,
@@ -964,13 +980,11 @@ async function runCompany(
           compact
         );
       }
-      // Family executors: each takes (staged, session, target) and returns
-      // a MultiStepResult. All gate on session.json existing.
-      // --via-cdp forces the puppeteer DOM-driven path for any adapter,
-      // bypassing the API endpoint and any body-shape uncertainty. The
-      // CDP executor walks the SPA's apply form like a human: click
-      // "投递", fill name/email/phone, upload resume, click submit.
-      // Slower + needs Chrome, but reliable when API is uncertain.
+      // Submission flow selection by submit_kind. Generic multipart families
+      // use submitApplication; proprietary families use a dedicated executor.
+      const isAnonMultipart = kind === "multipart-anon";
+      const isSessionMultipart = kind === "multipart-session";
+      const isGenericMultipart = isAnonMultipart || isSessionMultipart;
       const familyExecutor = viaCdp ? executeCdpRealBrowser :
         kind === "feishu-3-step" ? executeFeishu3Step :
         kind === "moka-aes" ? executeMokaApply :
@@ -978,6 +992,29 @@ async function runCompany(
         kind === "beisen-italent" ? executeBeisenITalent :
         kind === "cdp-real-browser" ? executeCdpRealBrowser :
         null;
+
+      if (!familyExecutor && !isGenericMultipart) {
+        return emit(
+          {
+            ok: false,
+            source: company,
+            post_id: postId,
+            mode: blockedMode,
+            staged,
+            submit_kind: kind,
+            submit_notes: sr.schema.submit_notes,
+            message:
+              `submit_kind="${kind}" is unknown — no wired executor. The 7 ` +
+              `current families are: multipart-anon, multipart-session, ` +
+              `feishu-3-step, moka-aes, beisen-wecruit, beisen-italent, ` +
+              `cdp-real-browser. To add a new family, wire an executor in ` +
+              `cli/src/apply.ts. Use --debug-submit-to <url> in the meantime ` +
+              `to verify the wire format you'd want.`,
+          },
+          compact
+        );
+      }
+
       if (familyExecutor) {
         // --via-cdp on multipart-anon (xpeng/weride/hoyoverse) doesn't
         // need a session — Greenhouse/Lever forms accept anon submits.
@@ -989,7 +1026,7 @@ async function runCompany(
               ok: false,
               source: company,
               post_id: postId,
-              mode: "really-submit-blocked",
+              mode: blockedMode,
               staged,
               submit_kind: kind,
               message:
@@ -1007,7 +1044,7 @@ async function runCompany(
               ok: false,
               source: company,
               post_id: postId,
-              mode: "really-submit-blocked",
+              mode: blockedMode,
               staged,
               submit_kind: kind,
               session_age_days: age,
@@ -1020,57 +1057,24 @@ async function runCompany(
             compact
           );
         }
-        const result = await familyExecutor(staged, session, { kind: "upstream" });
-        if (result.ok) {
-          memoryEvent("applied", `${company} ${postId} — ${staged.job_title}`);
+      } else if (!isAnonMultipart) {
+        if (!session) {
+          return emit(
+            {
+              ok: false,
+              source: company,
+              post_id: postId,
+              mode: blockedMode,
+              staged,
+              message:
+                `no captured session at ~/.jobpro/${company}.session.json. Run ` +
+                `\`job-pro extension\` for the bundled MV3 path + Chrome install ` +
+                `walkthrough; log into the careers site, click Export, then ` +
+                `mv ~/Downloads/jobpro/${company}.session.json ~/.jobpro/`,
+            },
+            compact
+          );
         }
-        return emit({ mode: "really-submit", staged, submit_kind: kind, session_used: true, result }, compact);
-      }
-      if (!isGenericMultipart) {
-        // Reachable only if a schema returns a SubmitKind that isn't in the
-        // current taxonomy (multipart-anon/session/feishu-3-step/moka-aes/
-        // beisen-wecruit/beisen-italent/cdp-real-browser/external). The
-        // SubmitKind type permits `(string & {})` extensibility, so a future
-        // contributor adding a new family without wiring it would land here.
-        return emit(
-          {
-            ok: false,
-            source: company,
-            post_id: postId,
-            mode: "really-submit-blocked",
-            staged,
-            submit_kind: kind,
-            submit_notes: sr.schema.submit_notes,
-            message:
-              `submit_kind="${kind}" is unknown — no wired executor. The 7 ` +
-              `current families are: multipart-anon, multipart-session, ` +
-              `feishu-3-step, moka-aes, beisen-wecruit, beisen-italent, ` +
-              `cdp-real-browser. To add a new family, wire an executor in ` +
-              `cli/src/apply.ts. Use --debug-submit-to <url> in the meantime ` +
-              `to verify the wire format you'd want.`,
-          },
-          compact
-        );
-      }
-      // Non-anon multipart families need session.json.
-      if (!isAnonMultipart && !session) {
-        return emit(
-          {
-            ok: false,
-            source: company,
-            post_id: postId,
-            mode: "really-submit-blocked",
-            staged,
-            message:
-              `no captured session at ~/.jobpro/${company}.session.json. Run ` +
-              `\`job-pro extension\` for the bundled MV3 path + Chrome install ` +
-              `walkthrough; log into the careers site, click Export, then ` +
-              `mv ~/Downloads/jobpro/${company}.session.json ~/.jobpro/`,
-          },
-          compact
-        );
-      }
-      if (!isAnonMultipart) {
         const age = sessionAgeDays(session);
         if (age !== null && age > maxAgeDays && !allowStaleSession) {
           return emit(
@@ -1078,7 +1082,7 @@ async function runCompany(
               ok: false,
               source: company,
               post_id: postId,
-              mode: "really-submit-blocked",
+              mode: blockedMode,
               staged,
               submit_kind: kind,
               session_age_days: age,
@@ -1090,11 +1094,98 @@ async function runCompany(
           );
         }
       }
+
+      if (confirmSubmit) {
+        if (compact) {
+          return emit(
+            {
+              ok: false,
+              source: company,
+              post_id: postId,
+              mode: blockedMode,
+              staged,
+              message:
+                `--confirm-submit is interactive and cannot run with --compact. ` +
+                `Drop --compact, or use JOB_PRO_I_UNDERSTAND_REAL_SUBMIT=yes with --really-submit for scripts.`,
+            },
+            compact
+          );
+        }
+        if (!process.stdin.isTTY) {
+          return emit(
+            {
+              ok: false,
+              source: company,
+              post_id: postId,
+              mode: blockedMode,
+              staged,
+              message:
+                `--confirm-submit needs an interactive terminal for the final consent prompt. ` +
+                `Use --really-submit with JOB_PRO_I_UNDERSTAND_REAL_SUBMIT=yes in non-interactive scripts.`,
+            },
+            compact
+          );
+        }
+        const confirmed = await confirmRealApplicationSubmit({
+          company,
+          postId,
+          staged,
+          session,
+        });
+        if (!confirmed) {
+          return emit(
+            {
+              ok: false,
+              source: company,
+              post_id: postId,
+              mode: "confirm-submit-cancelled",
+              staged,
+              message: "submission cancelled by user",
+            },
+            compact
+          );
+        }
+      } else {
+        const understood = process.env.JOB_PRO_I_UNDERSTAND_REAL_SUBMIT === "yes";
+        if (!understood) {
+          return emit(
+            {
+              ok: false,
+              source: company,
+              post_id: postId,
+              mode: "really-submit-blocked",
+              staged,
+              message:
+                `--really-submit is gated by an env-var attestation. To unlock, set ` +
+                `JOB_PRO_I_UNDERSTAND_REAL_SUBMIT=yes in your shell. This submission will ` +
+                `POST a real application to ${staged.submit_endpoint}; doing so without a ` +
+                `valid resume / answers is spam against the company's recruiters. For an interactive ` +
+                `one-shot flow, use --confirm-submit instead.`,
+            },
+            compact
+          );
+        }
+      }
+
+      // Family executors: each takes (staged, session, target) and returns
+      // a MultiStepResult. All gate on session.json existing.
+      // --via-cdp forces the puppeteer DOM-driven path for any adapter,
+      // bypassing the API endpoint and any body-shape uncertainty. The
+      // CDP executor walks the SPA's apply form like a human: click
+      // "投递", fill name/email/phone, upload resume, click submit.
+      // Slower + needs Chrome, but reliable when API is uncertain.
+      if (familyExecutor) {
+        const result = await familyExecutor(staged, session, { kind: "upstream" });
+        if (result.ok) {
+          memoryEvent("applied", `${company} ${postId} — ${staged.job_title}`);
+        }
+        return emit({ mode: confirmSubmit ? "confirm-submit" : "really-submit", staged, submit_kind: kind, session_used: !!session, result }, compact);
+      }
       const result = await submitApplication(staged, { kind: "upstream" }, { session });
       if (result.ok) {
         memoryEvent("applied", `${company} ${postId} — ${staged.job_title}`);
       }
-      return emit({ mode: "really-submit", staged, submit_kind: kind, session_used: !!session, result }, compact);
+      return emit({ mode: confirmSubmit ? "confirm-submit" : "really-submit", staged, submit_kind: kind, session_used: !!session, result }, compact);
     }
 
     // Default: dry-run print, no network.
@@ -1124,7 +1215,8 @@ async function runCompany(
       console.log(
         `\nDry-run complete. To actually submit:\n` +
           `  • --debug-submit-to https://httpbin.org/post  — verify wire format\n` +
-          `  • JOB_PRO_I_UNDERSTAND_REAL_SUBMIT=yes job-pro ${company} apply ${postId} --really-submit\n` +
+          `  • job-pro ${company} apply ${postId} --confirm-submit  — preview, confirm, submit\n` +
+          `  • JOB_PRO_I_UNDERSTAND_REAL_SUBMIT=yes job-pro ${company} apply ${postId} --really-submit  — script mode\n` +
           (isAnon
             ? `  ${company} is Greenhouse/Lever (anonymous submission, no session needed).\n`
             : `  ${company} needs ~/.jobpro/${company}.session.json — capture via the browser extension.\n`)

--- a/cli/src/netease.ts
+++ b/cli/src/netease.ts
@@ -525,7 +525,7 @@ export async function matchResume(
   let finalList = scored.slice(0, topN);
   if (!finalList.length) {
     // Fall back: return first topN from list without enrichment
-    finalList = listResult.positions.slice(0, topN).map((position) => ({
+    finalList = pool.slice(0, topN).map((position) => ({
       score: 0,
       position,
       reasons: [],

--- a/cli/src/vivo.ts
+++ b/cli/src/vivo.ts
@@ -34,7 +34,7 @@
 //
 // ============================================================
 
-import { extractResumeSignals, scoreOverlap, checkResume, pickDistinctiveTerms } from "./tencent.js";
+import { extractResumeSignals, scoreOverlap, checkResume } from "./tencent.js";
 export { checkResume };
 
 const SOURCE = "vivo.zhiye.com";

--- a/docs/auto-apply.md
+++ b/docs/auto-apply.md
@@ -13,10 +13,11 @@ applications) is partially shipped as of `0.9.1`:
 * **Session bridge** (`extension/`) — manifest-v3 Chrome extension that
   captures Cookie + CSRF/XSRF headers from any of the 50 careers sites
   the user logs into, and exports them as `~/.jobpro/<adapter>.session.json`.
-* **`--really-submit`** is gated behind `JOB_PRO_I_UNDERSTAND_REAL_SUBMIT=yes`
-  AND (for non-anon adapters) requires `~/.jobpro/<co>.session.json` to
-  exist. Both gates can be cleared with explicit user action; we never
-  fire a submission without them.
+* **`--confirm-submit`** is the human-in-the-loop submit path: stage the
+  form, show the final payload, ask once, then fire the right official-site
+  submitter. **`--really-submit`** remains for scripts and is gated behind
+  `JOB_PRO_I_UNDERSTAND_REAL_SUBMIT=yes`. Non-anon adapters still require
+  `~/.jobpro/<co>.session.json`.
 
 ## Quickstart
 
@@ -27,14 +28,17 @@ $EDITOR ~/.jobpro/profile.json # fill first_name / last_name / email / phone / r
 # Greenhouse / Lever (anonymous submission)
 job-pro xpeng apply 8548990002                                  # dry-run
 job-pro xpeng apply 8548990002 --debug-submit-to https://httpbin.org/post
+job-pro xpeng apply 8548990002 --confirm-submit                 # preview → confirm → submit
+
+# Non-interactive script mode:
 JOB_PRO_I_UNDERSTAND_REAL_SUBMIT=yes \
-  job-pro xpeng apply 8548990002 --really-submit                # actually fires
+  job-pro xpeng apply 8548990002 --really-submit
 
 # Adapters needing session.json (Beisen / Moka / Feishu / bespoke):
 # 1. job-pro extension  (prints path + 6-step Chrome install walkthrough)
 # 2. Log into the careers site in your normal browser
 # 3. Click extension → Export → mv ~/Downloads/jobpro/<co>.session.json ~/.jobpro/
-# 4. job-pro <co> apply <postId> --really-submit (with the env-var set)
+# 4. job-pro <co> apply <postId> --confirm-submit
 ```
 
 ## Rollout matrix (50 / 50)
@@ -170,11 +174,11 @@ Run `job-pro recon` for the live matrix any time.
 
 **Next: real-session validation.** All 45 verified endpoints have a
 real route at the right URL. The body shape might still differ from
-what the real upstream expects. To fully ship a `--really-submit`,
+what the real upstream expects. To fully validate a real submitter,
 each adapter needs:
 
 1. A captured candidate session (browser extension).
-2. A real `--really-submit` fire to confirm the upstream accepts the
+2. A real `--confirm-submit` fire to confirm the upstream accepts the
    multipart body we construct.
 3. If 4xx, inspect the network tab for the actual body shape, patch
    the buildMultipartForm path for that adapter family.
@@ -221,9 +225,8 @@ For each 🔑 unblock, the workflow:
 3. mv ~/Downloads/jobpro/<co>.session.json ~/.jobpro/
 4. job-pro <co> apply <id> --debug-submit-to <your-echo>
    # inspect the multipart body shape going out
-5. JOB_PRO_I_UNDERSTAND_REAL_SUBMIT=yes \
-   JOB_PRO_ALLOW_SPECULATIVE_ENDPOINT=yes \
-   job-pro <co> apply <id> --really-submit
+5. JOB_PRO_ALLOW_SPECULATIVE_ENDPOINT=yes \
+   job-pro <co> apply <id> --confirm-submit
    # 200 OK = success; 4xx = the specific path is wrong, network-tab
    # XHR shows real path → patch adapter
 6. Set endpoint_verified: true in the adapter + add to ENDPOINT_VERIFIED
@@ -234,21 +237,23 @@ For each 🔑 unblock, the workflow:
    is recruiter-IM-mediated; `apply_url` opens the chat in browser
    (already the right UX).
 
-## Why we don't auto-submit yet
+## Why auto-submit still asks once
 
-A real `--really-submit` from a bug-ridden first version to a real
-Greenhouse board sends a real application to a real recruiter. That's
-worse than a read-side bug. Hence the layered safety:
+Submitting from a bug-ridden first version to a real Greenhouse board
+sends a real application to a real recruiter. That's worse than a
+read-side bug. Hence the layered safety:
 
 1. Default verb is dry-run (no network).
 2. `--debug-submit-to <url>` requires an explicit echo URL.
-3. `--really-submit` requires `JOB_PRO_I_UNDERSTAND_REAL_SUBMIT=yes`.
+3. `--confirm-submit` requires a final interactive confirmation after
+   showing the staged resume / answers; `--really-submit` requires
+   `JOB_PRO_I_UNDERSTAND_REAL_SUBMIT=yes` for scripts.
 4. Non-anon adapters additionally require `~/.jobpro/<co>.session.json`
    to exist (i.e. you've explicitly captured a session via the
    extension).
 
 Together these mean a submission only fires when the user has explicitly:
 - captured their session in the browser,
-- attested to the env-var prompt,
-- run a verb that says "really submit",
+- confirmed the final staged payload or opted into script mode,
+- run a verb that says "submit",
 - and have a complete profile + resume on disk.

--- a/examples/walkthrough.md
+++ b/examples/walkthrough.md
@@ -169,19 +169,26 @@ your chosen echo server.
 ## Stage 6 — Actually submit
 
 ```bash
+$ job-pro xpeng apply 8548990002 --form-file /tmp/form.json --confirm-submit
+
+# Script mode is still available when you intentionally want no prompt:
 $ JOB_PRO_I_UNDERSTAND_REAL_SUBMIT=yes \
     job-pro xpeng apply 8548990002 --form-file /tmp/form.json --really-submit
 ```
 
-Three gates fire before any HTTP request:
+Four gates fire before any HTTP request:
 
-1. `JOB_PRO_I_UNDERSTAND_REAL_SUBMIT=yes` env attestation.
+1. User consent: either type `submit` in the `--confirm-submit` prompt,
+   or set `JOB_PRO_I_UNDERSTAND_REAL_SUBMIT=yes` for script mode.
 2. `staged.ready` — every required field has a value.
-3. For non-anon adapters (everyone except Greenhouse/Lever), a captured
+3. `endpoint_verified === true` unless you explicitly set
+   `JOB_PRO_ALLOW_SPECULATIVE_ENDPOINT=yes` while probing.
+4. For non-anon adapters (everyone except Greenhouse/Lever), a captured
    `~/.jobpro/<adapter>.session.json` from the browser extension.
 
 Missing any of those, the CLI returns `mode: "really-submit-blocked"`
-with a pointed remediation message instead of firing anything.
+or `mode: "confirm-submit-blocked"` with a pointed remediation message
+instead of firing anything.
 
 ## Stage 7 — Log it
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  sharp: true

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -481,8 +481,10 @@ job-pro find "intern" --apply-ready --text   # only show buckets you can fire to
 job-pro xpeng apply <id> --schema                  # peek at the form
 job-pro xpeng apply <id> --interactive --remember  # fill in terminal; persist answers
 
-# actually submit (4-layer safety gate: env attest + staged.ready
-# + endpoint_verified + session.json <30d)
+# actually submit (preview → confirm → official-site submitter)
+job-pro xpeng apply <id> --confirm-submit
+
+# script mode is still available when you intentionally want no prompt
 JOB_PRO_I_UNDERSTAND_REAL_SUBMIT=yes \\
   job-pro xpeng apply <id> --really-submit`}</pre>
         <p className="phase2-detail">


### PR DESCRIPTION
## Summary
- add `apply --confirm-submit` / `--submit-after-confirm` so users can preview, type `submit`, and then fire the existing official-site submitter
- keep `--really-submit` for script mode while moving ready/session/endpoint gates before the interactive prompt
- sync README, auto-apply docs, walkthrough, homepage snippet, and changelog
- allow `sharp` builds under pnpm 11 and fix three TypeScript drifts exposed after rebasing onto latest `main`

## Tests
- `cd cli && npm run build`
- `cd cli && npm run test:unit`
- `pnpm build`
- black-box CLI gates for XPeng/Unitree/NIO confirm-submit, alias, batch refusal, no-env really-submit, and TTY cancel paths

No real applications were submitted during testing.